### PR TITLE
Update GH actions to use JDK 17 (Temurin)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,8 +13,8 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
-          java-version: '16'
+          distribution: 'temurin'
+          java-version: '17'
       - uses: actions/cache@v2
         with:
           path: |


### PR DESCRIPTION
This PR switches from the deprecated AdoptJDK to the newer Temurin JDK. It also switches the version to 17 since your buildscript is using 17 as the toolchain.